### PR TITLE
Pp incomplete orders

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'bangazonapi',
     'safedelete',
+    'bangazonreports'
 ]
 
 REST_FRAMEWORK = {

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from django.conf import settings
 from django.conf.urls import url, include
 from django.conf.urls.static import static
@@ -27,4 +28,5 @@ urlpatterns = [
     url(r'^login$', login_user),
     url(r'^api-token-auth$', obtain_auth_token),
     url(r'^api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path('', include('bangazonreports.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -7,7 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from bangazonapi.models import Order, Customer, Product
+from bangazonapi.models import Order, Customer, Product, customer
 from bangazonapi.models import OrderProduct, Favorite
 from bangazonapi.models import Recommendation
 from .product import ProductSerializer
@@ -82,8 +82,8 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=request.auth.user)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
-            current_user.recommendations = Recommendation.objects.filter(customer=current_user)
+            current_user.recommends = Recommendation.objects.filter(customer=current_user)
+            current_user.recommendations = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})

--- a/bangazonreports/admin.py
+++ b/bangazonreports/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/bangazonreports/apps.py
+++ b/bangazonreports/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class BangazonreportsConfig(AppConfig):
+    name = 'bangazonreports'

--- a/bangazonreports/templates/orders/list_with_incomplete_orders.html
+++ b/bangazonreports/templates/orders/list_with_incomplete_orders.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Bangazon Reports</title>
+    </head>
+    <body>
+        <h1>Incomplete Orders</h1>
+        
+        {% for order in incompleteorders_list %}
+            <h2>Order #{{order.id}}</h2>
+            <ul>
+                <li>
+                    Customer: {{ order.full_name }}<br />
+                    Total: ${{ order.total }}
+                </li>
+            </ul>
+        {% endfor %}
+    </body>
+</html>

--- a/bangazonreports/templates/users/list_with_favorites.html
+++ b/bangazonreports/templates/users/list_with_favorites.html
@@ -10,13 +10,13 @@
         
         {% for user in userfavorites_list %}
             <h2>{{user.customer_name}}</h2>
-            <ol>
+            <ul>
                 {% for seller in user.sellers %}
                 <li>
                     {{ seller.seller_name }}
                 </li>
                 {% endfor %}
-            </ol>
+            </ul>
         {% endfor %}
     </body>
 </html>

--- a/bangazonreports/templates/users/list_with_favorites.html
+++ b/bangazonreports/templates/users/list_with_favorites.html
@@ -1,0 +1,22 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Bangazon Reports</title>
+    </head>
+    <body>
+        <h1>Favorites Sellers By User</h1>
+        
+        {% for user in userfavorites_list %}
+            <h2>{{user.customer_name}}</h2>
+            <ol>
+                {% for seller in user.sellers %}
+                <li>
+                    {{ seller.seller_name }}
+                </li>
+                {% endfor %}
+            </ol>
+        {% endfor %}
+    </body>
+</html>

--- a/bangazonreports/tests.py
+++ b/bangazonreports/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import userfavorite_list
+
+urlpatterns = [
+    path('reports/userfavorites', userfavorite_list),
+]

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import userfavorite_list
+from .views import userfavorite_list, incompleteorder_list
 
 urlpatterns = [
     path('reports/userfavorites', userfavorite_list),
+    path('reports/incompleteorders', incompleteorder_list),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,0 +1,2 @@
+from .connection import Connection
+from .users.favoritesbyuser import userfavorite_list

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,2 +1,3 @@
 from .connection import Connection
 from .users.favoritesbyuser import userfavorite_list
+from .orders.incompleteorders import incompleteorder_list

--- a/bangazonreports/views/connection.py
+++ b/bangazonreports/views/connection.py
@@ -1,0 +1,2 @@
+class Connection:
+    db_path = "/Users/phillipphan/workspace/bangazon-api-phillipphan/db.sqlite3"

--- a/bangazonreports/views/orders/incompleteorders.py
+++ b/bangazonreports/views/orders/incompleteorders.py
@@ -1,0 +1,50 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+def incompleteorder_list(request):
+    if request.method == "GET":
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+                SELECT
+                    o.id,
+                    u.first_name || ' ' || u.last_name AS full_name,
+                    SUM(p.price) AS total
+                FROM
+                    bangazonapi_order  o
+                JOIN
+                    bangazonapi_customer c ON c.id = o.customer_id
+                JOIN
+                    auth_user u ON u.id = c.user_id
+                JOIN
+                    bangazonapi_orderproduct op ON op.order_id = o.id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                WHERE
+                    payment_type_id IS NULL
+                GROUP BY
+                    o.id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            incomplete_orders = {}
+
+            for row in dataset:
+                uid = row["id"]
+
+                incomplete_orders[uid] = {}
+                incomplete_orders[uid]["id"] = uid
+                incomplete_orders[uid]["total"] = row["total"]
+                incomplete_orders[uid]["full_name"] = row["full_name"]
+            
+    list_of_incomplete_orders = incomplete_orders.values()
+
+    template = "orders/list_with_incomplete_orders.html"
+    context = {
+        "incompleteorders_list": list_of_incomplete_orders
+    }
+
+    return render(request, template, context)

--- a/bangazonreports/views/users/favoritesbyuser.py
+++ b/bangazonreports/views/users/favoritesbyuser.py
@@ -1,0 +1,57 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonapi.models import Customer
+from bangazonreports.views import Connection
+
+def userfavorite_list(request):
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+                SELECT
+                    c.id AS customer_id,
+                    c.phone_number,
+                    c.address,
+                    u.first_name || ' ' || u.last_name AS customer_name,
+                    su.first_name || ' ' || su.last_name AS seller_name
+                FROM 
+                    bangazonapi_customer c
+                LEFT JOIN
+                    bangazonapi_favorite f ON f.customer_id = c.id
+                JOIN
+                    auth_user u ON c.user_id = u.id
+                LEFT JOIN
+                    bangazonapi_customer sc ON f.seller_id = sc.id
+                LEFT JOIN
+                    auth_user su ON sc.user_id = su.id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            favorites_by_user = {}
+
+            for row in dataset:
+                seller = Customer()
+                seller.seller_name = row["seller_name"]
+                uid = row["customer_id"]
+
+                if uid in favorites_by_user:
+                    favorites_by_user[uid]["sellers"].append(seller)
+
+                else:
+                    favorites_by_user[uid] = {}
+                    favorites_by_user[uid]["id"] = uid
+                    favorites_by_user[uid]["customer_name"] = row["customer_name"]
+                    favorites_by_user[uid]["address"] = row["address"]
+                    favorites_by_user[uid]["phone_number"] = row["phone_number"]
+                    favorites_by_user[uid]["sellers"] = [seller]
+
+        list_of_users_with_favorites = favorites_by_user.values()
+
+        template = 'users/list_with_favorites.html'
+        context = {
+            'userfavorites_list': list_of_users_with_favorites
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
Added server side rendering for a list of incomplete orders with the order ID, customer name, and total of the order.

## Changes

- added a path in reports for incomplete orders

## Requests / Responses

**Request**

GET `/reports/incompleteorders` Renders a list of incomplete orders with details

**Response**

HTTP representation of the incomplete orders

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #3