### PR TITLE
Pp complete orders

### DIFF
--- a/bangazonreports/templates/orders/list_with_complete_orders.html
+++ b/bangazonreports/templates/orders/list_with_complete_orders.html
@@ -1,0 +1,22 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Bangazon Reports</title>
+    </head>
+    <body>
+        <h1>Complete Orders</h1>
+        
+        {% for order in completeorders_list %}
+            <h2>Order #{{order.id}}</h2>
+            <ul>
+                <li>
+                    Customer: {{ order.full_name }}<br />
+                    Total: ${{ order.total }}<br />
+                    Payment Type: {{ order.merchant_name }}
+                </li>
+            </ul>
+        {% endfor %}
+    </body>
+</html>

--- a/bangazonreports/templates/orders/list_with_incomplete_orders.html
+++ b/bangazonreports/templates/orders/list_with_incomplete_orders.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Bangazon Reports</title>
+    </head>
+    <body>
+        <h1>Incomplete Orders</h1>
+        
+        {% for order in incompleteorders_list %}
+            <h2>Order #{{order.id}}</h2>
+            <ul>
+                <li>
+                    Customer: {{ order.full_name }}<br />
+                    Total: ${{ order.total }}
+                </li>
+            </ul>
+        {% endfor %}
+    </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import userfavorite_list
+from .views import userfavorite_list, incompleteorder_list
 
 urlpatterns = [
     path('reports/userfavorites', userfavorite_list),
+    path('reports/incompleteorders', incompleteorder_list),
 ]

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import userfavorite_list, incompleteorder_list
+from .views import userfavorite_list, incompleteorder_list, completeorder_list
 
 urlpatterns = [
     path('reports/userfavorites', userfavorite_list),
     path('reports/incompleteorders', incompleteorder_list),
+    path('reports/completeorders', completeorder_list),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,2 +1,3 @@
 from .connection import Connection
 from .users.favoritesbyuser import userfavorite_list
+from .orders.incompleteorders import incompleteorder_list

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,3 +1,4 @@
 from .connection import Connection
 from .users.favoritesbyuser import userfavorite_list
 from .orders.incompleteorders import incompleteorder_list
+from .orders.completeorders import completeorder_list

--- a/bangazonreports/views/orders/completeorders.py
+++ b/bangazonreports/views/orders/completeorders.py
@@ -1,0 +1,55 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+def completeorder_list(request):
+    if request.method == "GET":
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+                SELECT
+                    o.id,
+                    u.first_name || ' ' || u.last_name AS full_name,
+                    pay.merchant_name,
+                    SUM(p.price) AS total
+                FROM
+                    bangazonapi_order  o
+                JOIN
+                    bangazonapi_customer c ON c.id = o.customer_id
+                JOIN
+                    auth_user u ON u.id = c.user_id
+                JOIN
+                    bangazonapi_orderproduct op ON op.order_id = o.id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                JOIN
+                    bangazonapi_payment pay ON pay.id = o.payment_type_id
+                WHERE
+                    payment_type_id IS NOT NULL
+                GROUP BY
+                    o.id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            complete_orders = {}
+
+            for row in dataset:
+                uid = row["id"]
+
+                complete_orders[uid] = {}
+                complete_orders[uid]["id"] = uid
+                complete_orders[uid]["total"] = row["total"]
+                complete_orders[uid]["full_name"] = row["full_name"]
+                complete_orders[uid]["merchant_name"] = row["merchant_name"]
+
+            
+    list_of_complete_orders = complete_orders.values()
+
+    template = "orders/list_with_complete_orders.html"
+    context = {
+        "completeorders_list": list_of_complete_orders
+    }
+
+    return render(request, template, context)

--- a/bangazonreports/views/orders/incompleteorders.py
+++ b/bangazonreports/views/orders/incompleteorders.py
@@ -1,0 +1,50 @@
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+def incompleteorder_list(request):
+    if request.method == "GET":
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+            db_cursor.execute("""
+                SELECT
+                    o.id,
+                    u.first_name || ' ' || u.last_name AS full_name,
+                    SUM(p.price) AS total
+                FROM
+                    bangazonapi_order  o
+                JOIN
+                    bangazonapi_customer c ON c.id = o.customer_id
+                JOIN
+                    auth_user u ON u.id = c.user_id
+                JOIN
+                    bangazonapi_orderproduct op ON op.order_id = o.id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                WHERE
+                    payment_type_id IS NULL
+                GROUP BY
+                    o.id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            incomplete_orders = {}
+
+            for row in dataset:
+                uid = row["id"]
+
+                incomplete_orders[uid] = {}
+                incomplete_orders[uid]["id"] = uid
+                incomplete_orders[uid]["total"] = row["total"]
+                incomplete_orders[uid]["full_name"] = row["full_name"]
+            
+    list_of_incomplete_orders = incomplete_orders.values()
+
+    template = "orders/list_with_incomplete_orders.html"
+    context = {
+        "incompleteorders_list": list_of_incomplete_orders
+    }
+
+    return render(request, template, context)


### PR DESCRIPTION
Added server side rendering for a list of complete orders with the order ID, customer name, total of the order, and payment method.

## Changes

- added a path in reports for complete orders

## Requests / Responses

**Request**

GET `/reports/completeorders` Renders a list of complete orders with details

**Response**

HTTP representation of the complete orders

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #4