### PR TITLE
fixed error for division by 0 for ratings

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,10 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        if len(ratings) != 0:
+            avg = total_rating / len(ratings)
+        else:
+            avg = 0
         return avg
 
     class Meta:

--- a/tests/product.py
+++ b/tests/product.py
@@ -98,3 +98,5 @@ class ProductTests(APITestCase):
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.
+    # def test_rate_product(self):
+


### PR DESCRIPTION
fixed error that said ratings were being divided by zero

## Changes

- added an if else statement that gives a rating of 0 if there are no reviews

## Requests / Responses

**Request**

GET `/profile/cart` Gets a user's cart without getting an error for dividing the rating by zero

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #15