### PR TITLE
Pp duplicate line items

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,7 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],)
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,10 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        if len(ratings) != 0:
+            avg = total_rating / len(ratings)
+        else:
+            avg = 0
         return avg
 
     class Meta:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -185,7 +185,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/tests/product.py
+++ b/tests/product.py
@@ -98,3 +98,5 @@ class ProductTests(APITestCase):
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.
+    # def test_rate_product(self):
+

--- a/tests/product.py
+++ b/tests/product.py
@@ -98,5 +98,5 @@ class ProductTests(APITestCase):
     # TODO: Delete product
 
     # TODO: Product can be rated. Assert average rating exists.
-    # def test_rate_product(self):
+    
 


### PR DESCRIPTION
removed duplicate line items from user's cart

## Changes

- deleted the line_items from the response for user's cart

## Requests / Responses

**Request**

GET `/profile/cart` Gets the user's cart without any duplicates

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #24