### PR TITLE
fixed incorrect result for minimum products sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
fixed incorrect result for minimum products sold

## Changes

- changed the filter in the product viewset to return products greater than the minimum value

## Requests / Responses

**Request**

GET `/products?number_sold=2` Lists products that have sold more than 2 products

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #21