### PR TITLE
Pp products by price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        price = self.request.query_params.get('price', None)
 
         if order is not None:
             order_filter = order
@@ -272,7 +273,13 @@ class Products(ViewSet):
                     return True
                 return False
 
-            products = filter(sold_filter, products)
+        if price is not None:
+            def price_filter(product):
+                if product.price >= int(price):
+                    return True
+                return False
+
+            products = filter(price_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,7 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
-        price = self.request.query_params.get('price', None)
+        price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order


### PR DESCRIPTION
products can be filtered by price through URL

## Changes

- added a filter in the products viewset that looks for min_price in URL

## Requests / Responses

**Request**

GET `/products?min_price=1899` Lists products with price greater than or equal to 1899.00

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #17